### PR TITLE
[feat/#43] Head 공통 컴포넌트 구현

### DIFF
--- a/src/shared/components/head/Head.css.ts
+++ b/src/shared/components/head/Head.css.ts
@@ -1,0 +1,34 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@/shared/styles/theme.css';
+
+export const headStyle = recipe({
+  variants: {
+    tag: {
+      head_bold_60: vars.font.head_bold_60,
+      head_bold_28: vars.font.head_bold_28,
+      head_bold_24: vars.font.head_bold_24,
+      head_sb_24: vars.font.head_sb_24,
+      head_bold_20: vars.font.head_bold_20,
+      head_sb_20: vars.font.head_sb_20,
+      head_medium_20: vars.font.head_medium_20,
+      head_regular_20: vars.font.head_regular_20,
+    },
+    color: {
+      white: { color: vars.color.white },
+      black: { color: vars.color.black },
+      gray1: { color: vars.color.gray1 },
+      gray2: { color: vars.color.gray2 },
+      gray3: { color: vars.color.gray3 },
+      gray4: { color: vars.color.gray4 },
+      gray5: { color: vars.color.gray5 },
+      gray6: { color: vars.color.gray6 },
+      gray7: { color: vars.color.gray7 },
+      gray8: { color: vars.color.gray8 },
+      gray8_30: { color: vars.color.gray8_30 },
+      point_red: { color: vars.color.point_red },
+      point_orange: { color: vars.color.point_orange },
+      point_orange2: { color: vars.color.point_orange2 },
+      point_green: { color: vars.color.point_green },
+    },
+  },
+});

--- a/src/shared/components/head/Head.tsx
+++ b/src/shared/components/head/Head.tsx
@@ -1,0 +1,59 @@
+import clsx from 'clsx';
+import { forwardRef, type ComponentPropsWithRef } from 'react';
+import { headStyle } from '@/shared/components/head/Head.css';
+
+type HeadLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+type HeadTag =
+  | 'head_bold_60'
+  | 'head_bold_28'
+  | 'head_bold_24'
+  | 'head_sb_24'
+  | 'head_bold_20'
+  | 'head_sb_20'
+  | 'head_medium_20'
+  | 'head_regular_20';
+type HeadColor =
+  | 'white'
+  | 'black'
+  | 'gray1'
+  | 'gray2'
+  | 'gray3'
+  | 'gray4'
+  | 'gray5'
+  | 'gray6'
+  | 'gray7'
+  | 'gray8'
+  | 'gray8_30'
+  | 'point_red'
+  | 'point_orange'
+  | 'point_orange2'
+  | 'point_green';
+
+export interface HeadProps extends ComponentPropsWithRef<'h1'> {
+  level?: HeadLevel;
+  tag?: HeadTag;
+  color?: HeadColor;
+}
+
+const HeadTagMap = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
+} as const;
+
+const Head = forwardRef<HTMLHeadingElement, HeadProps>(
+  ({ level = 'h1', tag = 'head_bold_24', color = 'black', className, children, ...props }, ref) => {
+    const Tag = HeadTagMap[level];
+
+    return (
+      <Tag className={clsx(className, headStyle({ tag, color }))} ref={ref} {...props}>
+        {children}
+      </Tag>
+    );
+  }
+);
+
+export default Head;


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close https://github.com/SOPT-all/36-COLLABORATION-WEB-TEMU/issues/43

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- 각 페이지에서 공통적으로 사용될 `Head` 컴포넌트를 구현했습니다.
- `tag`, `color`는 `@vanilla-extract/recipes`의 `variant`로 설정했습니다.
- HTML 태그 (`<h1>`~`<h6>`)를 level prop으로 지정할 수 있도록 구성했습니다.

## ⭐ PR Point (To Reviewer)

```typescript
const Head = forwardRef<HTMLHeadingElement, HeadProps>(
  ({ level = 'h1', tag = 'head_bold_24', color = 'black', className, children, ...props }, ref) => {
    const Tag = HeadTagMap[level];

    return (
      <Tag className={clsx(className, headStyle({ tag, color }))} ref={ref} {...props}>
        {children}
      </Tag>
    );
  }
);
```
- level: HTML 태그(`<h1>`~`<h6>`)를 지정합니다.
- tag: font size, font weight, line height를 지정합니다.
- color: color를 지정합니다.
- className: 외부 스타일을 병합할 수 있습니다.
- 기본값: level = 'h1', tag = 'head_bold_24', color = 'black'

```typescript
// 예시 사용 방법
<Head level="h2" tag="head_bold_28" color="point_orange">
  TEMU
</Head>
```

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/250683e1-ee5c-4da2-a8d0-817db8fe1971)


## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
