### PR TITLE
[feat/#92] 검색 페이지에 useDebounce 적용 및 세부 페이지로 이동 시 검색어 초기화 X

### DIFF
--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -36,7 +36,10 @@ const Header = () => {
   }, [debouncedKeyword, isSearchPage, navigate]);
 
   useEffect(() => {
-    if (location.pathname !== '/products') {
+    const isProductSearchPage = location.pathname === '/products';
+    const isProductDetailPage = /^\/products\/\d+$/.test(location.pathname);
+
+    if (!isProductSearchPage && !isProductDetailPage) {
       setKeyword('');
     }
   }, [location.pathname]);

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -5,16 +5,21 @@ import clsx from 'clsx';
 import { PLACEHOLDER, MIN_HEIGHT } from '@shared/components/header/constant';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ROUTES } from '@router/constant/routes';
+import useDebounce from '@shared/hooks/useDebounce';
 
 const Header = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const isSearchPage = location.pathname === '/products';
   const [keyword, setKeyword] = useState('');
   const [isScrolled, setIsScrolled] = useState(false);
+  const debounced = useDebounce(keyword, 300);
+  const debouncedKeyword = isSearchPage ? debounced : keyword;
 
   const handleLogoClick = () => {
     navigate(ROUTES.HOME);
   };
+
   useEffect(() => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > MIN_HEIGHT);
@@ -23,6 +28,12 @@ const Header = () => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
+
+  useEffect(() => {
+    if (isSearchPage) {
+      navigate(`/products?keyword=${encodeURIComponent(debouncedKeyword)}`);
+    }
+  }, [debouncedKeyword, isSearchPage, navigate]);
 
   useEffect(() => {
     if (location.pathname !== '/products') {

--- a/src/shared/hooks/useDebounce.ts
+++ b/src/shared/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce<T>(value: T, delay = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
## 📌 Related Issues

- close https://github.com/SOPT-all/36-COLLABORATION-WEB-TEMU/issues/92

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- useDebounce를 검색 페이지(/products)에만 적용
- 다른 페이지에서는 엔터 or 검색 아이콘 클릭 시에만 검색 수행
- 제품 상세 페이지로 이동 시 키워드 초기화 X

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
https://github.com/user-attachments/assets/6e2ebdb0-0a91-4c48-8ced-095436c7870d
- 용량 줄이느라 워터마크가 들어갔어요 😶‍🌫️


## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
